### PR TITLE
feat: allow running CLI without installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ pip install -e .  # editable install
 
 # run CLI
 risk-pipeline --help
+
+# or run directly without installing the package
+python scripts/run_pipeline.py --help  # auto-adds src/ to PYTHONPATH
 ```
 
 ## Project layout

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,3 +1,17 @@
+"""Entry point for running the CLI without installing the package.
+
+This script ensures that the ``src`` directory is added to ``sys.path`` so
+that ``risk_pipeline`` can be imported even when the project hasn't been
+installed. It mirrors the behaviour of the ``risk-pipeline`` console script
+defined in ``pyproject.toml``.
+"""
+
+from pathlib import Path
+import sys
+
+# Add ``src`` to ``sys.path`` to allow running without ``PYTHONPATH``.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
 from risk_pipeline.cli import app
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enable run_pipeline.py to add `src` to `sys.path`
- document running CLI directly without installing package

## Testing
- `pytest`
- `python scripts/run_pipeline.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a5756b844083328dc3db0cd9807524